### PR TITLE
User murmur instead of md5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
 'use strict'
 var fs = require('graceful-fs');
 var chain = require('slide').chain;
-var crypto = require('crypto');
+var MurmurHash3 = require('imurmurhash');
 
-var md5hex = function () {
-    var hash = crypto.createHash('md5');
-    for (var ii=0; ii<arguments.length; ++ii) hash.update(''+arguments[ii])
-    return hash.digest('hex')
+function murmurhex () {
+  var hash = MurmurHash3('');
+  for (var ii=0; ii<arguments.length; ++ii) {
+    hash.hash(hash+arguments[ii]);
+  }
+  return hash.result();
 }
 var invocations = 0;
 var getTmpname = function (filename) {
-    return filename + "." + md5hex(__filename, process.pid, ++invocations)
+    return filename + "." + murmurhex(__filename, process.pid, ++invocations)
 }
 
 module.exports = function writeFile(filename, data, options, callback) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "homepage": "https://github.com/iarna/write-file-atomic",
   "dependencies": {
     "graceful-fs": "^4.1.2",
-    "slide": "^1.1.5"
+    "slide": "^1.1.5",
+    "imurmurhash": "^0.1.4"
   },
   "devDependencies": {
     "require-inject": "^1.1.0",


### PR DESCRIPTION
MD5 is disallowed in FIPS mode, use a pure JS
version of murmur instead.

Resolves https://github.com/iarna/write-file-atomic/issues/6
Based on https://github.com/npm/fs-write-stream-atomic/pull/6