### PR TITLE
Preserve chmod and chown from overwritten file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: node_js
-sudo: false
+sudo: true
 before_install:
   - "npm -g install npm"
+script:
+  - "sudo $(which node) $(which npm) test"
+os:
+  - osx
+  - linux
+matrix:
+  fast_finish: true
+  allow_failures:
+    - os: osx
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "iojs"
   - "4"
+  - "6"
+  - "0.10"
   - "5"
+  - "0.12"

--- a/index.js
+++ b/index.js
@@ -20,22 +20,83 @@ module.exports = function writeFile (filename, data, options, callback) {
   }
   if (!options) options = {}
   var tmpfile = getTmpname(filename)
-  chain([
-    [fs, fs.writeFile, tmpfile, data, options],
-    options.chown && [fs, fs.chown, tmpfile, options.chown.uid, options.chown.gid],
-    [fs, fs.rename, tmpfile, filename]
-  ], function (err) {
-    err ? fs.unlink(tmpfile, function () { callback(err) })
-      : callback()
+
+  function computeOptions (filename, cb) {
+    if (options.mode && options.chmod) {
+      cb(options)
+    } else {
+      // Either mode or chown is not explicitly set
+      // Default behavior is to copy it from original file
+      fs.stat(filename, function (err, stats) {
+        var newOptions = {}
+        for (var key in options) {
+          if ({}.hasOwnProperty.call(options, key)) {
+            newOptions[key] = options[key]
+          }
+        }
+        if (!err && stats && !options.mode) {
+          newOptions.mode = stats.mode
+        }
+        if (!err && stats && !options.chown && process.getuid) {
+          newOptions.chown = { uid: stats.uid, gid: stats.gid }
+        }
+        cb(newOptions)
+      })
+    }
+  }
+
+  // We can't use computeOptions as part of chain because
+  // "options.chown &&" is evaluated before computeOptions has chance to run
+  computeOptions(filename, function (options) {
+    chain([
+      [fs, fs.writeFile, tmpfile, data, options.encoding || 'utf8'],
+      options.mode && [fs, fs.chmod, tmpfile, options.mode],
+      options.chown && [fs, fs.chown, tmpfile, options.chown.uid, options.chown.gid],
+      [fs, fs.rename, tmpfile, filename]
+    ], function (err) {
+      err ? fs.unlink(tmpfile, function () { callback(err) })
+        : callback()
+    })
   })
 }
 
 module.exports.sync = function writeFileSync (filename, data, options) {
   if (!options) options = {}
   var tmpfile = getTmpname(filename)
+
+  function computeOptions (options, filename, cb) {
+    if (!options.mode || !options.chmod) {
+      var newOptions = {}
+      for (var key in options) {
+        if ({}.hasOwnProperty.call(options, key)) {
+          newOptions[key] = options[key]
+        }
+      }
+      // Either mode or chown is not explicitly set
+      // Default behavior is to copy it from original file
+      try {
+        var stats = fs.statSync(filename)
+
+        if (!options.mode) {
+          newOptions.mode = stats.mode
+        }
+        if (!options.chown && process.getuid) {
+          newOptions.chown = { uid: stats.uid, gid: stats.gid }
+        }
+      } catch (e) {
+      }
+
+      return newOptions
+    }
+
+    return options
+  }
+
   try {
-    fs.writeFileSync(tmpfile, data, options)
+    options = computeOptions(options, filename)
+    fs.writeFileSync(tmpfile, data, options.encoding || 'utf8')
     if (options.chown) fs.chownSync(tmpfile, options.chown.uid, options.chown.gid)
+    if (options.mode) fs.chmodSync(tmpfile, options.mode)
     fs.renameSync(tmpfile, filename)
   } catch (err) {
     try { fs.unlinkSync(tmpfile) } catch (e) {}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "require-inject": "^1.1.0",
     "standard": "^5.4.1",
-    "tap": "^2.3.1"
+    "tap": "^2.3.1",
+    "tmp": "0.0.28"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -11,6 +11,10 @@ var writeFileAtomic = requireInject('../index', {
       if (/nochown/.test(tmpfile)) return cb(new Error('ENOCHOWN'))
       cb()
     },
+    chmod: function (tmpfile, mode, cb) {
+      if (/nochmod/.test(tmpfile)) return cb(new Error('ENOCHMOD'))
+      cb()
+    },
     rename: function (tmpfile, filename, cb) {
       if (/norename/.test(tmpfile)) return cb(new Error('ENORENAME'))
       cb()
@@ -19,17 +23,27 @@ var writeFileAtomic = requireInject('../index', {
       if (/nounlink/.test(tmpfile)) return cb(new Error('ENOUNLINK'))
       cb()
     },
+    stat: function (tmpfile, cb) {
+      if (/nostat/.test(tmpfile)) return cb(new Error('ENOSTAT'))
+      cb()
+    },
     writeFileSync: function (tmpfile, data, options) {
       if (/nowrite/.test(tmpfile)) throw new Error('ENOWRITE')
     },
     chownSync: function (tmpfile, uid, gid) {
       if (/nochown/.test(tmpfile)) throw new Error('ENOCHOWN')
     },
+    chmodSync: function (tmpfile, mode) {
+      if (/nochmod/.test(tmpfile)) throw new Error('ENOCHMOD')
+    },
     renameSync: function (tmpfile, filename) {
       if (/norename/.test(tmpfile)) throw new Error('ENORENAME')
     },
     unlinkSync: function (tmpfile) {
       if (/nounlink/.test(tmpfile)) throw new Error('ENOUNLINK')
+    },
+    statSync: function (tmpfile) {
+      if (/nostat/.test(tmpfile)) throw new Error('ENOSTAT')
     }
   }
 })

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,0 +1,118 @@
+'use strict'
+var test = require('tap').test
+var writeFileAtomic = require('../index')
+var fs = require('fs')
+var tmp = require('tmp')
+
+function tmpPath () {
+  // We need to manually set os temp dir because of:
+  // https://github.com/npm/npm/issues/4531#issuecomment-226294103
+  var dir = tmp.dirSync({ dir: '/tmp' }).name
+  return tmp.tmpNameSync({ dir: dir })
+}
+
+function readFile (path) {
+  return fs.readFileSync(path).toString()
+}
+
+test('writes simple file (async)', function (t) {
+  t.plan(1)
+  var path = tmpPath()
+  writeFileAtomic(path, '42', function (err) {
+    if (err) throw err
+    t.is(readFile(path), '42')
+  })
+})
+
+test('runs chown on given file (async)', function (t) {
+  t.plan(2)
+  var path = tmpPath()
+  writeFileAtomic(path, '42', { chown: { uid: 42, gid: 43 } }, function (err) {
+    if (err) throw err
+    var stat = fs.statSync(path)
+    t.is(stat.uid, 42)
+    t.is(stat.gid, 43)
+  })
+})
+
+test('runs chmod on given file (async)', function (t) {
+  t.plan(1)
+  var path = tmpPath()
+  writeFileAtomic(path, '42', { mode: parseInt('741', 8) }, function (err) {
+    if (err) throw err
+    var stat = fs.statSync(path)
+    t.is(stat.mode, parseInt('100741', 8))
+  })
+})
+
+test('does not change chmod by default (async)', function (t) {
+  t.plan(1)
+  var path = tmpPath()
+  writeFileAtomic(path, '42', { mode: parseInt('741', 8) }, function (err) {
+    if (err) throw err
+
+    writeFileAtomic(path, '43', function (err) {
+      if (err) throw err
+      var stat = fs.statSync(path)
+      t.is(stat.mode, parseInt('100741', 8))
+    })
+  })
+})
+
+test('does not change chown by default (async)', function (t) {
+  t.plan(2)
+  var path = tmpPath()
+  writeFileAtomic(path, '42', { chown: { uid: 42, gid: 43 } }, function (err) {
+    if (err) throw err
+
+    writeFileAtomic(path, '43', function (err) {
+      if (err) throw err
+      var stat = fs.statSync(path)
+      t.is(stat.uid, 42)
+      t.is(stat.gid, 43)
+    })
+  })
+})
+
+test('writes simple file (sync)', function (t) {
+  t.plan(1)
+  var path = tmpPath()
+  writeFileAtomic.sync(path, '42')
+  t.is(readFile(path), '42')
+})
+
+test('runs chown on given file (sync)', function (t) {
+  t.plan(2)
+  var path = tmpPath()
+  writeFileAtomic.sync(path, '42', { chown: { uid: 42, gid: 43 } })
+  var stat = fs.statSync(path)
+  t.is(stat.uid, 42)
+  t.is(stat.gid, 43)
+})
+
+test('runs chmod on given file (sync)', function (t) {
+  t.plan(1)
+  var path = tmpPath()
+  writeFileAtomic.sync(path, '42', { mode: parseInt('741', 8) })
+  var stat = fs.statSync(path)
+  t.is(stat.mode, parseInt('100741', 8))
+})
+
+test('does not change chmod by default (sync)', function (t) {
+  t.plan(1)
+  var path = tmpPath()
+  writeFileAtomic.sync(path, '42', { mode: parseInt('741', 8) })
+  writeFileAtomic.sync(path, '43')
+  var stat = fs.statSync(path)
+  t.is(stat.mode, parseInt('100741', 8))
+})
+
+test('does not change chown by default (sync)', function (t) {
+  t.plan(2)
+  var path = tmpPath()
+  writeFileAtomic.sync(path, '42', { chown: { uid: 42, gid: 43 } })
+  writeFileAtomic.sync(path, '43')
+  var stat = fs.statSync(path)
+  t.is(stat.uid, 42)
+  t.is(stat.gid, 43)
+})


### PR DESCRIPTION
Among others it fixes:

- https://github.com/npm/write-file-atomic/issues/11
- https://github.com/yeoman/update-notifier/issues/76
- https://github.com/tessel/t2-cli/issues/727
- [bower permission issues](https://github.com/bower/bower/issues?q=is%3Aissue+configstore+is%3Aclosed)
- [f**kton](https://github.com/search?p=2&q=configstore+permission&ref=searchresults&type=Issues&utf8=%E2%9C%93) of similar ones