### PR TITLE
fsync after write to handle crashes better

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = writeFile
 module.exports.sync = writeFileSync
 module.exports._getTmpname = getTmpname // for testing
 
+var ofs = require('fs')
 var fs = require('graceful-fs')
 var chain = require('slide').chain
 var MurmurHash3 = require('imurmurhash')
@@ -89,7 +90,10 @@ function writeFileSync (filename, data, options) {
       }
     }
 
-    fs.writeFileSync(tmpfile, data, options.encoding || 'utf8')
+    var fd = ofs.openSync(tmpfile, 'w', options.mode)
+    ofs.writeSync(fd, data, 0, options.encoding || 'utf8')
+    ofs.fsyncSync(fd)
+    ofs.closeSync(fd)
     if (options.chown) fs.chownSync(tmpfile, options.chown.uid, options.chown.gid)
     if (options.mode) fs.chmodSync(tmpfile, options.mode)
     fs.renameSync(tmpfile, filename)


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/npm/write-file-atomic/issues/16. In order to get a file descriptor we have to use `openSync`, `writeSync`, etc. That lets us flush before we close the file.

This causes a few basic tests to fail, but the test output is not clear why:
```
sync tests
not ok missing test
sync tests
not ok missing test
sync tests
not ok missing test
sync tests
not ok missing test
```