### PR TITLE
Update check to only add chown if undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ it encounters errors at any of these steps it will attempt to unlink the tempora
 pass the error back to the caller.
 
 If provided, the **chown** option requires both **uid** and **gid** properties or else
-you'll get an error. If **chown** is not specified it will default to using the owner of the previous file.  To prevent chown from being used you can also pass `false`
+you'll get an error. If **chown** is not specified it will default to using the owner of the previous file.  To prevent chown from being ran you can also pass `false`
 
 The **encoding** option is ignored if **data** is a buffer. It defaults to 'utf8'.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ it encounters errors at any of these steps it will attempt to unlink the tempora
 pass the error back to the caller.
 
 If provided, the **chown** option requires both **uid** and **gid** properties or else
-you'll get an error.
+you'll get an error. If **chown** is not specified it will default to using the owner of the previous file.  To prevent chown from being used you can also pass `false`
 
 The **encoding** option is ignored if **data** is a buffer. It defaults to 'utf8'.
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function _writeFile (filename, data, options, callback) {
       if (!options.mode) {
         options.mode = stats.mode
       }
-      if (!options.chown && process.getuid) {
+      if (typeof options.chown === 'undefined' && process.getuid) {
         options.chown = { uid: stats.uid, gid: stats.gid }
       }
       return thenWriteFile()

--- a/test/basic.js
+++ b/test/basic.js
@@ -113,7 +113,7 @@ test('async tests', function (t) {
 })
 
 test('sync tests', function (t) {
-  t.plan(9)
+  t.plan(10)
   var throws = function (shouldthrow, msg, todo) {
     var err
     try { todo() } catch (e) { err = e }
@@ -140,8 +140,11 @@ test('sync tests', function (t) {
   throws('ENOCHOWN', 'Chown failures propagate', function () {
     writeFileAtomicSync('nochown', 'test', {chown: {uid: 100, gid: 100}})
   })
-  noexception('No attempt to chown when no uid/gid passed in', function () {
-    writeFileAtomicSync('nochown', 'test')
+  noexception('No attempt to chown when false passed in', function () {
+    writeFileAtomicSync('nochown', 'test', {chown: false})
+  })
+  noexception('No errors occured when chown is undefined and original file owner used', function () {
+    writeFileAtomicSync('chowncopy', 'test', {chown: undefined})
   })
   throws('ENORENAME', 'Rename errors propagate', function () {
     writeFileAtomicSync('norename', 'test')

--- a/test/integration.js
+++ b/test/integration.js
@@ -125,6 +125,16 @@ test('runs chown on given file (async)', function (t) {
   })
 })
 
+test('writes simple file with no chown (async)', function (t) {
+  t.plan(3)
+  var file = tmpFile()
+  didWriteFileAtomic(t, {}, file, '42', { chown: false }, function (err) {
+    t.ifError(err, 'no error')
+    t.is(readFile(file), '42', 'content ok')
+    t.done()
+  })
+})
+
 test('runs chmod on given file (async)', function (t) {
   t.plan(5)
   var file = tmpFile()


### PR DESCRIPTION
This way if we set it to false it won't try and chown the file.  In some isolated environments operations like chown are not allowed.  So making it only try and set it when nothing is being passed solves this.