### PR TITLE
Flattened execution chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ function writeFile (filename, data, options, callback) {
     options = null
   }
   if (!options) options = {}
-  
+
   var truename
   var fd
   var tmpfile
-  
+
   new Promise(function (resolve) {
     fs.realpath(filename, function (_, realname) {
       truename = realname || filename

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function writeFile (filename, data, options, callback) {
           if (err || !stats) resolve()
           else {
             options = Object.assign({}, options)
-            
+
             if (!options.mode) {
               options.mode = stats.mode
             }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ module.exports.sync = writeFileSync
 module.exports._getTmpname = getTmpname // for testing
 
 var fs = require('graceful-fs')
-// var chain = require('slide').chain
 var MurmurHash3 = require('imurmurhash')
 
 var invocations = 0
@@ -22,92 +21,97 @@ function writeFile (filename, data, options, callback) {
     options = null
   }
   if (!options) options = {}
-  fs.realpath(filename, function (_, realname) {
-    _writeFile(realname || filename, data, options, callback)
-  })
-}
-function _writeFile (filename, data, options, callback) {
-  var tmpfile = getTmpname(filename)
-  new Promise(function stat (resolve, reject) {
-    if (options.mode && options.chown) resolve()
-    else {
-      // Either mode or chown is not explicitly set
-      // Default behavior is to copy it from original file
-      fs.stat(filename, function (err, stats) {
-        if (err || !stats) resolve()
-        else {
-          options = Object.assign({}, options)
-          if (!options.mode) {
-            options.mode = stats.mode
+  
+  var truename
+  var fd
+  var tmpfile
+  
+  new Promise(function (resolve) {
+    fs.realpath(filename, function (_, realname) {
+      truename = realname || filename
+      tmpfile = getTmpname(truename)
+      resolve()
+    })
+  }).then(function () {
+    return new Promise(function stat (resolve) {
+      if (options.mode && options.chown) resolve()
+      else {
+        // Either mode or chown is not explicitly set
+        // Default behavior is to copy it from original file
+        fs.stat(truename, function (err, stats) {
+          if (err || !stats) resolve()
+          else {
+            options = Object.assign({}, options)
+            if (!options.mode) {
+              options.mode = stats.mode
+            }
+            if (!options.chown && process.getuid) {
+              options.chown = { uid: stats.uid, gid: stats.gid }
+            }
+            resolve()
           }
-          if (!options.chown && process.getuid) {
-            options.chown = { uid: stats.uid, gid: stats.gid }
-          }
-          resolve()
-        }
-      })
-    }
+        })
+      }
+    })
   }).then(function thenWriteFile () {
-    var fd
-    
     return new Promise(function (resolve, reject) {
       fs.open(tmpfile, 'w', options.mode, function (err, _fd) {
         fd = _fd
         if (err) reject(err)
         else resolve()
       })
-    }).then(function write () {
-      return new Promise(function (resolve, reject) {
-        if (Buffer.isBuffer(data)) {
-          fs.write(fd, data, 0, data.length, 0, function (err) {
-            if (err) reject(err)
-            else resolve()
-          })
-        } else if (data != null) {
-          fs.write(fd, String(data), 0, String(options.encoding || 'utf8'), function (err) {
-            if (err) reject(err)
-            else resolve()
-          })
-        } else resolve()
-      })
-    }).then(function syncAndClose () {
-      return new Promise(function (resolve, reject) {
-        fs.fsync(fd, function (err) {
+    })
+  }).then(function write () {
+    return new Promise(function (resolve, reject) {
+      if (Buffer.isBuffer(data)) {
+        fs.write(fd, data, 0, data.length, 0, function (err) {
           if (err) reject(err)
-          else fs.close(fd, resolve)
+          else resolve()
         })
+      } else if (data != null) {
+        fs.write(fd, String(data), 0, String(options.encoding || 'utf8'), function (err) {
+          if (err) reject(err)
+          else resolve()
+        })
+      } else resolve()
+    })
+  }).then(function syncAndClose () {
+    return new Promise(function (resolve, reject) {
+      fs.fsync(fd, function (err) {
+        if (err) reject(err)
+        else fs.close(fd, resolve)
       })
-    }).then(function chown () {
-      if (options.chown) {
-        return new Promise(function (resolve, reject) {
-          fs.chown(tmpfile, options.chown.uid, options.chown.gid, function (err) {
-            if (err) reject(err)
-            else resolve()
-          })
-        })
-      }
-    }).then(function chmod () {
-      if (options.mode) {
-        return new Promise(function (resolve, reject) {
-          fs.chmod(tmpfile, options.mode, function (err) {
-            if (err) reject(err)
-            else resolve()
-          })
-        })
-      }
-    }).then(function rename () {
+    })
+  }).then(function chown () {
+    if (options.chown) {
       return new Promise(function (resolve, reject) {
-        fs.rename(tmpfile, filename, function (err) {
+        fs.chown(tmpfile, options.chown.uid, options.chown.gid, function (err) {
           if (err) reject(err)
           else resolve()
         })
       })
-    }).then(function success () {
-      callback()
-    }).catch(function fail (err) {
-      fs.unlink(tmpfile, function () {
-        callback(err)
+    }
+  }).then(function chmod () {
+    if (options.mode) {
+      return new Promise(function (resolve, reject) {
+        fs.chmod(tmpfile, options.mode, function (err) {
+          if (err) reject(err)
+          else resolve()
+        })
       })
+    }
+  }).then(function rename () {
+    return new Promise(function (resolve, reject) {
+      fs.rename(tmpfile, truename, function (err) {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }).then(function success () {
+    callback()
+  }).catch(function fail (err) {
+    fs.unlink(tmpfile, function () {
+      callback(err)
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "write-file-atomic",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Write files in an atomic fashion w/configurable ownership",
   "main": "index.js",
   "scripts": {
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/iarna/write-file-atomic",
   "dependencies": {
     "graceful-fs": "^4.1.11",
-    "imurmurhash": "^0.1.4",
-    "slide": "^1.1.5"
+    "imurmurhash": "^0.1.4"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",

--- a/test/basic.js
+++ b/test/basic.js
@@ -82,7 +82,7 @@ test('getTmpname', function (t) {
 })
 
 test('async tests', function (t) {
-  t.plan(9)
+  t.plan(11)
   writeFileAtomic('good', 'test', {mode: '0777'}, function (err) {
     t.notOk(err, 'No errors occur when passing in options')
   })
@@ -95,11 +95,17 @@ test('async tests', function (t) {
   writeFileAtomic('nowrite', 'test', function (err) {
     t.is(err && err.message, 'ENOWRITE', 'fs.writewrite failures propagate')
   })
+  writeFileAtomic('nowrite', Buffer.from('test', 'utf8'), function (err) {
+    t.is(err && err.message, 'ENOWRITE', 'fs.writewrite failures propagate for buffers')
+  })
   writeFileAtomic('nochown', 'test', {chown: {uid: 100, gid: 100}}, function (err) {
     t.is(err && err.message, 'ENOCHOWN', 'Chown failures propagate')
   })
   writeFileAtomic('nochown', 'test', function (err) {
     t.notOk(err, 'No attempt to chown when no uid/gid passed in')
+  })
+  writeFileAtomic('nochmod', 'test', { mode: parseInt('741', 8) }, function (err) {
+    t.is(err && err.message, 'ENOCHMOD', 'Chmod failures propagate')
   })
   writeFileAtomic('norename', 'test', function (err) {
     t.is(err && err.message, 'ENORENAME', 'Rename errors propagate')


### PR DESCRIPTION
This change greatly simplifies the operation of write-file-atomic, while also maintaining all functionality. It eliminates the dependency on slide-flow-control and replaces it with promises (I have a PR for that one too! https://github.com/npm/slide-flow-control/pull/10)

Everything related to writeFile has been condensed into a single function with a single promise chain, and is very easy to read and follow.

I did this because I felt the nested callbacks pattern was overly complicated. I found it difficult to understand what was going on while investigating the following issue (and wrestling with this problem in my own project, not on github) : 

- https://github.com/valery-barysok/session-file-store/issues/51
- https://github.com/isaacs/node-graceful-fs/issues/104

I have a suspicion that these errors are caused on windows when a dependent package calls write-file-atomic multiple times on the same file, attempting to overwrite a file currently being written to. On Unix systems the behavior of fs.rename() simply replaces the file, but on Windows it is apparently more complicated! I have an idea on how to fix it and will make another pull request soon if it works.