### PR TITLE
Serialize Writes to the Same File (Fixes EPERM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ atomic and allows you set ownership (uid/gid of the file).
   * encoding **String** | **Null** default = 'utf8'
   * fsync **Boolean** default = true
   * mode **Number** default = 438 (aka 0666 in Octal)
+  * Promise **Object** default = native Promise object
 callback **Function**
 
 Atomically and asynchronously writes data to a file, replacing the file if it already
@@ -25,6 +26,7 @@ If writeFile completes successfully then, if passed the **chown** option it will
 the ownership of the file. Finally it renames the file back to the filename you specified. If
 it encounters errors at any of these steps it will attempt to unlink the temporary file and then
 pass the error back to the caller.
+If multiple writes are concurrently issued to the same file, the write operations are put into a queue and serialized in the order they were called, using Promises. Native promises are used by default, but you can inject your own promise-like object with the **Promise** option. Writes to different files are still executed in parallel.
 
 If provided, the **chown** option requires both **uid** and **gid** properties or else
 you'll get an error.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ module.exports.sync = writeFileSync
 module.exports._getTmpname = getTmpname // for testing
 
 var fs = require('graceful-fs')
-var chain = require('slide').chain
 var MurmurHash3 = require('imurmurhash')
 
 var invocations = 0
@@ -22,69 +21,104 @@ function writeFile (filename, data, options, callback) {
     options = null
   }
   if (!options) options = {}
-  fs.realpath(filename, function (_, realname) {
-    _writeFile(realname || filename, data, options, callback)
-  })
-}
-function _writeFile (filename, data, options, callback) {
-  var tmpfile = getTmpname(filename)
 
-  if (options.mode && options.chown) {
-    return thenWriteFile()
-  } else {
-    // Either mode or chown is not explicitly set
-    // Default behavior is to copy it from original file
-    return fs.stat(filename, function (err, stats) {
-      if (err || !stats) return thenWriteFile()
+  var truename
+  var fd
+  var tmpfile
 
-      options = Object.assign({}, options)
-      if (!options.mode) {
-        options.mode = stats.mode
-      }
-      if (!options.chown && process.getuid) {
-        options.chown = { uid: stats.uid, gid: stats.gid }
-      }
-      return thenWriteFile()
+  new Promise(function (resolve) {
+    fs.realpath(filename, function (_, realname) {
+      truename = realname || filename
+      tmpfile = getTmpname(truename)
+      resolve()
     })
-  }
+  }).then(function () {
+    return new Promise(function stat (resolve) {
+      if (options.mode && options.chown) resolve()
+      else {
+        // Either mode or chown is not explicitly set
+        // Default behavior is to copy it from original file
+        fs.stat(truename, function (err, stats) {
+          if (err || !stats) resolve()
+          else {
+            options = Object.assign({}, options)
 
-  function thenWriteFile () {
-    chain([
-      [writeFileAsync, tmpfile, data, options.mode, options.encoding || 'utf8'],
-      options.chown && [fs, fs.chown, tmpfile, options.chown.uid, options.chown.gid],
-      options.mode && [fs, fs.chmod, tmpfile, options.mode],
-      [fs, fs.rename, tmpfile, filename]
-    ], function (err) {
-      err ? fs.unlink(tmpfile, function () { callback(err) })
-        : callback()
+            if (!options.mode) {
+              options.mode = stats.mode
+            }
+            if (!options.chown && process.getuid) {
+              options.chown = { uid: stats.uid, gid: stats.gid }
+            }
+            resolve()
+          }
+        })
+      }
     })
-  }
-
-  // doing this instead of `fs.writeFile` in order to get the ability to
-  // call `fsync`.
-  function writeFileAsync (file, data, mode, encoding, cb) {
-    fs.open(file, 'w', options.mode, function (err, fd) {
-      if (err) return cb(err)
+  }).then(function thenWriteFile () {
+    return new Promise(function (resolve, reject) {
+      fs.open(tmpfile, 'w', options.mode, function (err, _fd) {
+        fd = _fd
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }).then(function write () {
+    return new Promise(function (resolve, reject) {
       if (Buffer.isBuffer(data)) {
-        return fs.write(fd, data, 0, data.length, 0, syncAndClose)
+        fs.write(fd, data, 0, data.length, 0, function (err) {
+          if (err) reject(err)
+          else resolve()
+        })
       } else if (data != null) {
-        return fs.write(fd, String(data), 0, String(encoding), syncAndClose)
+        fs.write(fd, String(data), 0, String(options.encoding || 'utf8'), function (err) {
+          if (err) reject(err)
+          else resolve()
+        })
+      } else resolve()
+    })
+  }).then(function syncAndClose () {
+    return new Promise(function (resolve, reject) {
+      if (options.fsync !== false) {
+        fs.fsync(fd, function (err) {
+          if (err) reject(err)
+          else fs.close(fd, resolve)
+        })
       } else {
-        return syncAndClose()
-      }
-      function syncAndClose (err) {
-        if (err) return cb(err)
-        if (options.fsync !== false) {
-          fs.fsync(fd, function (err) {
-            if (err) return cb(err)
-            fs.close(fd, cb)
-          })
-        } else {
-          fs.close(fd, cb)
-        }
+        fs.close(fd, resolve)
       }
     })
-  }
+  }).then(function chown () {
+    if (options.chown) {
+      return new Promise(function (resolve, reject) {
+        fs.chown(tmpfile, options.chown.uid, options.chown.gid, function (err) {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
+    }
+  }).then(function chmod () {
+    if (options.mode) {
+      return new Promise(function (resolve, reject) {
+        fs.chmod(tmpfile, options.mode, function (err) {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
+    }
+  }).then(function rename () {
+    return new Promise(function (resolve, reject) {
+      fs.rename(tmpfile, truename, function (err) {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }).then(function success () {
+    callback()
+  }).catch(function fail (err) {
+    fs.unlink(tmpfile, function () {
+      callback(err)
+    })
+  })
 }
 
 function writeFileSync (filename, data, options) {
@@ -120,9 +154,7 @@ function writeFileSync (filename, data, options) {
     } else if (data != null) {
       fs.writeSync(fd, String(data), 0, String(options.encoding || 'utf8'))
     }
-    if (options.fsync !== false) {
-      fs.fsyncSync(fd)
-    }
+    fs.fsyncSync(fd)
     fs.closeSync(fd)
     if (options.chown) fs.chownSync(tmpfile, options.chown.uid, options.chown.gid)
     if (options.mode) fs.chmodSync(tmpfile, options.mode)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
   "name": "write-file-atomic",
-  "version": "2.1.0",
+  "version": "2.2.1",
+  "lockfileVersion": 1,
+  "packageIntegrity": "sha512-/Ji/yNTk4nE8/FH/VsIGjb3XSAymHCxUtx5s3igqhe7S294j//braZSMrC0eb8yk3fbGYuFPLepi2z2uafAsSg==",
   "dependencies": {
     "acorn": {
       "version": "5.0.3",
@@ -1089,7 +1091,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true
     },
     "minimist": {
@@ -1196,7 +1198,8 @@
         },
         "babel-generator": {
           "version": "6.24.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+          "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
           "dev": true
         },
         "babel-messages": {
@@ -1211,17 +1214,20 @@
         },
         "babel-template": {
           "version": "6.24.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+          "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
           "dev": true
         },
         "babel-traverse": {
           "version": "6.24.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+          "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
           "dev": true
         },
         "babel-types": {
           "version": "6.24.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+          "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
           "dev": true
         },
         "babylon": {
@@ -1231,12 +1237,14 @@
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true
         },
         "braces": {
@@ -1317,7 +1325,8 @@
         },
         "debug": {
           "version": "2.6.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
+          "integrity": "sha1-qfpvvpykPPHnn3O3XAGJy7fW21o=",
           "dev": true
         },
         "debug-log": {
@@ -1387,7 +1396,8 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true
         },
         "for-in": {
@@ -1442,12 +1452,14 @@
         },
         "handlebars": {
           "version": "4.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz",
+          "integrity": "sha1-Irh1zT8ObL6jAxTxROgrx6cv9CA=",
           "dev": true,
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true
             }
           }
@@ -1509,7 +1521,8 @@
         },
         "is-dotfile": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+          "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
           "dev": true
         },
         "is-equal-shallow": {
@@ -1589,7 +1602,8 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
+          "integrity": "sha1-Fp4xvGLHeIUamUOd2Zw8wSGE02A=",
           "dev": true
         },
         "istanbul-lib-report": {
@@ -1626,7 +1640,8 @@
         },
         "kind-of": {
           "version": "3.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+          "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
           "dev": true
         },
         "lazy-cache": {
@@ -1677,7 +1692,8 @@
         },
         "merge-source-map": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
+          "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8=",
           "dev": true
         },
         "micromatch": {
@@ -1702,7 +1718,8 @@
         },
         "ms": {
           "version": "0.7.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
           "dev": true
         },
         "normalize-package-data": {
@@ -1747,7 +1764,8 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true
         },
         "parse-glob": {
@@ -1837,7 +1855,8 @@
         },
         "remove-trailing-separator": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+          "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
           "dev": true
         },
         "repeat-element": {
@@ -1935,7 +1954,8 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true
         },
         "strip-ansi": {
@@ -1970,13 +1990,15 @@
         },
         "uglify-js": {
           "version": "2.8.22",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
           "dev": true,
           "optional": true,
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true
             }
@@ -2000,7 +2022,8 @@
         },
         "which-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
           "dev": true
         },
         "window-size": {
@@ -2041,17 +2064,20 @@
         },
         "yargs": {
           "version": "7.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true
             }
           }
@@ -2377,11 +2403,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "sntp": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "write-file-atomic",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Write files in an atomic fashion w/configurable ownership",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "write-file-atomic",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "Write files in an atomic fashion w/configurable ownership",
   "main": "index.js",
   "scripts": {
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/iarna/write-file-atomic",
   "dependencies": {
     "graceful-fs": "^4.1.11",
-    "imurmurhash": "^0.1.4",
-    "slide": "^1.1.5"
+    "imurmurhash": "^0.1.4"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",

--- a/test/basic.js
+++ b/test/basic.js
@@ -165,3 +165,18 @@ test('sync tests', function (t) {
     writeFileAtomicSync('nofsync', 'test')
   })
 })
+
+test('promise injection', function (t) {
+  t.plan(2)
+  var usedCustomPromise = false
+  class customPromise extends Promise {
+    then () {
+      usedCustomPromise = true
+      return super.then.apply(this, arguments)
+    }
+  }
+  writeFileAtomic('good', 'test', {Promise: customPromise}, function (err) {
+    t.notOk(err, 'no errors occur when providing customPromise')
+    t.true(usedCustomPromise, 'the custom promise was injected and used')
+  })
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -82,7 +82,7 @@ test('getTmpname', function (t) {
 })
 
 test('async tests', function (t) {
-  t.plan(10)
+  t.plan(12)
   writeFileAtomic('good', 'test', {mode: '0777'}, function (err) {
     t.notOk(err, 'No errors occur when passing in options')
   })
@@ -95,11 +95,17 @@ test('async tests', function (t) {
   writeFileAtomic('nowrite', 'test', function (err) {
     t.is(err && err.message, 'ENOWRITE', 'fs.writewrite failures propagate')
   })
+  writeFileAtomic('nowrite', Buffer.from('test', 'utf8'), function (err) {
+    t.is(err && err.message, 'ENOWRITE', 'fs.writewrite failures propagate for buffers')
+  })
   writeFileAtomic('nochown', 'test', {chown: {uid: 100, gid: 100}}, function (err) {
     t.is(err && err.message, 'ENOCHOWN', 'Chown failures propagate')
   })
   writeFileAtomic('nochown', 'test', function (err) {
     t.notOk(err, 'No attempt to chown when no uid/gid passed in')
+  })
+  writeFileAtomic('nochmod', 'test', { mode: parseInt('741', 8) }, function (err) {
+    t.is(err && err.message, 'ENOCHMOD', 'Chmod failures propagate')
   })
   writeFileAtomic('nofsyncopt', 'test', {fsync: false}, function (err) {
     t.notOk(err, 'fsync skipped if options.fsync is false')

--- a/test/concurrency.js
+++ b/test/concurrency.js
@@ -1,0 +1,141 @@
+'use strict'
+var test = require('tap').test
+var requireInject = require('require-inject')
+
+// defining mock for gracefulFs so its functions can be modified
+var gracefulFs = {
+  realpath: function (filename, cb) {
+    return cb(null, filename)
+  },
+  open: function (tmpfile, options, mode, cb) {
+    if (/noopen/.test(tmpfile)) return cb(new Error('ENOOPEN'))
+    cb(null, tmpfile)
+  },
+  write: function (fd) {
+    var cb = arguments[arguments.length - 1]
+    if (/nowrite/.test(fd)) return cb(new Error('ENOWRITE'))
+    cb()
+  },
+  fsync: function (fd, cb) {
+    if (/nofsync/.test(fd)) return cb(new Error('ENOFSYNC'))
+    cb()
+  },
+  close: function (fd, cb) { cb() },
+  chown: function (tmpfile, uid, gid, cb) {
+    if (/nochown/.test(tmpfile)) return cb(new Error('ENOCHOWN'))
+    cb()
+  },
+  chmod: function (tmpfile, mode, cb) {
+    if (/nochmod/.test(tmpfile)) return cb(new Error('ENOCHMOD'))
+    cb()
+  },
+  rename: function (tmpfile, filename, cb) {
+    if (/norename/.test(tmpfile)) return cb(new Error('ENORENAME'))
+    cb()
+  },
+  unlink: function (tmpfile, cb) {
+    if (/nounlink/.test(tmpfile)) return cb(new Error('ENOUNLINK'))
+    cb()
+  },
+  stat: function (tmpfile, cb) {
+    if (/nostat/.test(tmpfile)) return cb(new Error('ENOSTAT'))
+    cb()
+  },
+  realpathSync: function (filename, cb) {
+    return filename
+  },
+  openSync: function (tmpfile, options) {
+    if (/noopen/.test(tmpfile)) throw new Error('ENOOPEN')
+    return tmpfile
+  },
+  writeSync: function (fd) {
+    if (/nowrite/.test(fd)) throw new Error('ENOWRITE')
+  },
+  fsyncSync: function (fd) {
+    if (/nofsync/.test(fd)) throw new Error('ENOFSYNC')
+  },
+  closeSync: function () { },
+  chownSync: function (tmpfile, uid, gid) {
+    if (/nochown/.test(tmpfile)) throw new Error('ENOCHOWN')
+  },
+  chmodSync: function (tmpfile, mode) {
+    if (/nochmod/.test(tmpfile)) throw new Error('ENOCHMOD')
+  },
+  renameSync: function (tmpfile, filename) {
+    if (/norename/.test(tmpfile)) throw new Error('ENORENAME')
+  },
+  unlinkSync: function (tmpfile) {
+    if (/nounlink/.test(tmpfile)) throw new Error('ENOUNLINK')
+  },
+  statSync: function (tmpfile) {
+    if (/nostat/.test(tmpfile)) throw new Error('ENOSTAT')
+  }
+}
+
+var writeFileAtomic = requireInject('../index', {
+  'graceful-fs': gracefulFs
+})
+
+// preserve original functions
+var oldRealPath = gracefulFs.realpath
+var oldRename = gracefulFs.rename
+
+test('ensure writes to the same file are serial', function (t) {
+  var fileInUse = false
+  var ops = 5 // count for how many concurrent write ops to request
+  t.plan(ops * 3 + 3)
+  gracefulFs.realpath = function () {
+    t.false(fileInUse, 'file not in use')
+    fileInUse = true
+    oldRealPath.apply(writeFileAtomic, arguments)
+  }
+  gracefulFs.rename = function () {
+    t.true(fileInUse, 'file in use')
+    fileInUse = false
+    oldRename.apply(writeFileAtomic, arguments)
+  }
+  for (var i = 0; i < ops; i++) {
+    writeFileAtomic('test', 'test', function (err) {
+      if (err) t.fail(err)
+      else t.pass('wrote without error')
+    })
+  }
+  setTimeout(function () {
+    writeFileAtomic('test', 'test', function (err) {
+      if (err) t.fail(err)
+      else t.pass('successive writes after delay')
+    })
+  }, 500)
+})
+
+test('allow write to multiple files in parallel, but same file writes are serial', function (t) {
+  var filesInUse = []
+  var ops = 5
+  var wasParallel = false
+  gracefulFs.realpath = function (filename) {
+    filesInUse.push(filename)
+    var firstOccurence = filesInUse.indexOf(filename)
+    t.equal(filesInUse.indexOf(filename, firstOccurence + 1), -1, 'serial writes') // check for another occurence after the first
+    if (filesInUse.length > 1) wasParallel = true // remember that a parallel operation took place
+    oldRealPath.apply(writeFileAtomic, arguments)
+  }
+  gracefulFs.rename = function (filename) {
+    filesInUse.splice(filesInUse.indexOf(filename), 1)
+    oldRename.apply(writeFileAtomic, arguments)
+  }
+  t.plan(ops * 2 * 2 + 1)
+  var opCount = 0
+  for (var i = 0; i < ops; i++) {
+    writeFileAtomic('test', 'test', function (err) {
+      if (err) t.fail(err, 'wrote without error')
+      else t.pass('wrote without error')
+    })
+    writeFileAtomic('test2', 'test', function (err) {
+      opCount++
+      if (opCount === ops) t.true(wasParallel, 'parallel writes')
+
+      if (err) t.fail(err, 'wrote without error')
+      else t.pass('wrote without error')
+    })
+  }
+})


### PR DESCRIPTION
# The TL;DR:
This PR fixes many issues on dependent packages related to the EPERM issue on Windows platforms. In addition, it eliminates the dependency on slide-flow-control and replaces it with Promises. Awesome!

# How to reproduce the problem
**This issue only occurs on Windows platforms!** :drooling_face:
In whatever directory you fancy, do `$ npm i write-file-atomic tap` then create `test.js` with the following contents:
```'use strict'
let test = require('tap').test
let writeFileAtomic = require('write-file-atomic')

test('concurrency', function (t) {
  var ops = 15 // number of concurrent write operations to perform
  t.plan(ops)
  for (var i = 0; i < ops; i++) {
    writeFileAtomic('test.json', 'test', function (err) {
      if (err) t.fail(err)
      else t.pass()
    })
  }
})
```

Lastly, run `$ node test.js` and you should see multiple `EPERM: operation not permitted, rename '...' -> '...'` errors
If not, try increasing `ops` to increase the chances of getting a race condition

# (Possibly) related issues
-  https://github.com/isaacs/node-graceful-fs/issues/104
- https://github.com/npm/npm/issues/12059
- https://github.com/npm/npm/issues/9696 ([this fix](https://github.com/npm/npm/commit/39f012418b55d22a6d4f7b2f144aa075e5d1d986) felt too much like a bandaid IMO :confused:)
- https://github.com/npm/npm/issues/14028
- https://github.com/remy/nodemon/issues/901
- https://github.com/mantrajs/kickstart-mantrajs-webpack/issues/7
- https://github.com/npm/npm/issues/7885
- https://github.com/Medium/phantomjs/issues/19
- https://github.com/valery-barysok/session-file-store/issues/51
- https://github.com/heroku/cli-engine/pull/88

# Background
About a month ago I originally encountered this problem while performing a deployment to a windows dev server. I was baffled that the errors were occurring because it worked fine on my laptop. Whenever anyone accessed a page on my site after logging in, many EPERM errors were spat out. After a lot of poking around, I discovered that the problem was caused when npm installed all the latest packages specified in my package.json. As usual it tried to get the latest stuff that should still be compatible, and I guess that somewhere a breaking change was accidentally introduced. It was very difficult hunting down when, where, and why the error was occurring because of the way write-file-atomic and especially its dependency, slide-flow-control, are written (I still think they're both awesome btw. They aren't impossible to follow, it's just awkward).
I'm always going to advocate readability over compactness, and that's why I've also created PRs for [slide-flow-control](https://github.com/npm/slide-flow-control/pull/10) and [write-file-atomic](https://github.com/npm/write-file-atomic/pull/21) which helps make it at least easier to follow. Check them out!
###### Maybe if the PR doesn't work out we can make a kickstarter to get Isaac a bigger projector screen? #sizematters

I eventually traced the problem's roots to: session-file-store > write-file-atomic > graceful-fs on [this commit](https://github.com/isaacs/node-graceful-fs/commit/90a96bc2104729e51d5d7b4aebc8c584ccf7d2ce)
Of course, you could get rid of these errors by simply adding a npm-shrinkwrap.json. But....

# Here's why npm-shrinkwrap.json isn't enough
As Isaac wrote in the commit I mentioned above, the change is important because it causes a fast fail. For the project I was working on, requests to my site would trigger an update to the express session, which in turn triggered write-file-atomic to update the file store. Multiple requests would cause a sort of race condition, and only one attempt to modify the session would succeed. This explained why the temp files seemed to be successfully removed.
As a short term solution, I just added a npm-shrinkwrap.json to force an earlier version of graceful-fs. 
**But this does not fix the problem, it merely stifles it!!!**

# #justwindowsthings :roll_eyes: 
While doing my research on this problem, I kept seeing similar issues popping up here and there. It seems like the EPERM problem just doesn't want to die! And it ALWAYS seemed to occur on Windows platforms. 
So why the difference? Why isn't this a problem with *nix systems?
It boils down to the way that fs.rename is implemented. [The POSIX standard](http://pubs.opengroup.org/onlinepubs/009695399/functions/rename.html) says 

> If the link named by the new argument exists and the file's link count becomes 0 when it is removed and no process has the file open, the space occupied by the file shall be freed and the file shall no longer be accessible. If one or more processes have the file open when the last link is removed, the link shall be removed before rename() returns, but the removal of the file contents shall be postponed until all references to the file are closed.

Basically, *nix systems replace the destination file if it exists during rename. However on Windows systems, it's a bit more complicated! Also, unlike *nix systems, _the Windows rename() is not atomic!_

# The fix
In order to truly make the behavior of writing files be atomic on ALL platforms, my modifications to write-file-atomic adds a queue to keep track of the requested write operations. Writes to different files are allowed to execute in parallel, but writes to the _same_ file are serialized! I've tested that this does in fact solve my problems mentioned earlier, and I've even written tests to cover the added functionality. If you don't like my replacement of slide-flow-control with promises, I'd be happy to put together another PR that has just the serializing feature.

Hope this helps someone somewhere!