### PR TITLE
Return tmpfile to caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The **encoding** option is ignored if **data** is a buffer. It defaults to 'utf8
 
 If the **fsync** option is **false**, writeFile will skip the final fsync call.
 
+The callback is always invoked with the initial (temporary) filename.
+
 Example:
 
 ```javascript
@@ -44,4 +46,4 @@ writeFileAtomic('message.txt', 'Hello Node', {chown:{uid:100,gid:50}}, function 
 
 ### var writeFileAtomicSync = require('write-file-atomic').sync<br>writeFileAtomicSync(filename, data, [options])
 
-The synchronous version of **writeFileAtomic**.
+The synchronous version of **writeFileAtomic**. Returns the initial (temporary) filename.

--- a/index.js
+++ b/index.js
@@ -55,8 +55,8 @@ function _writeFile (filename, data, options, callback) {
       options.mode && [fs, fs.chmod, tmpfile, options.mode],
       [fs, fs.rename, tmpfile, filename]
     ], function (err) {
-      err ? fs.unlink(tmpfile, function () { callback(err) })
-        : callback()
+      err ? fs.unlink(tmpfile, function () { callback(err, tmpfile) })
+        : callback(null, tmpfile)
     })
   }
 
@@ -127,6 +127,7 @@ function writeFileSync (filename, data, options) {
     if (options.chown) fs.chownSync(tmpfile, options.chown.uid, options.chown.gid)
     if (options.mode) fs.chmodSync(tmpfile, options.mode)
     fs.renameSync(tmpfile, filename)
+    return tmpfile
   } catch (err) {
     try { fs.unlinkSync(tmpfile) } catch (e) {}
     throw err

--- a/test/basic.js
+++ b/test/basic.js
@@ -82,12 +82,16 @@ test('getTmpname', function (t) {
 })
 
 test('async tests', function (t) {
-  t.plan(10)
+  t.plan(14)
   writeFileAtomic('good', 'test', {mode: '0777'}, function (err) {
     t.notOk(err, 'No errors occur when passing in options')
   })
   writeFileAtomic('good', 'test', function (err) {
     t.notOk(err, 'No errors occur when NOT passing in options')
+  })
+  writeFileAtomic('good', 'test', function (err, tmpfile) {
+    t.notOk(err)
+    t.match(tmpfile, /^good\.\d+$/, 'Provides tmpfile in callback upon success')
   })
   writeFileAtomic('noopen', 'test', function (err) {
     t.is(err && err.message, 'ENOOPEN', 'fs.open failures propagate')
@@ -113,10 +117,14 @@ test('async tests', function (t) {
   writeFileAtomic('nofsync', 'test', function (err) {
     t.is(err && err.message, 'ENOFSYNC', 'Fsync failures propagate')
   })
+  writeFileAtomic('noopen', 'test', function (err, tmpfile) {
+    t.ok(err)
+    t.match(tmpfile, /^noopen\.\d+$/, 'Provides tmpfile in callback upon failure')
+  })
 })
 
 test('sync tests', function (t) {
-  t.plan(10)
+  t.plan(12)
   var throws = function (shouldthrow, msg, todo) {
     var err
     try { todo() } catch (e) { err = e }
@@ -133,6 +141,9 @@ test('sync tests', function (t) {
   })
   noexception('No errors occur when NOT passing in options', function () {
     writeFileAtomicSync('good', 'test')
+  })
+  noexception('Returns tmpfile upon success', function () {
+    t.match(writeFileAtomicSync('good', 'test'), /^good\.\d+$/)
   })
   noexception('fsync never called if options.fsync is falsy', function () {
     writeFileAtomicSync('good', 'test', {fsync: false})


### PR DESCRIPTION
I have a use case where a Node.js process watches the filesystem for changes. Workers may write files using `write-file-atomic` and communicate the file paths to their parent process. This allows the parent to ignore changes for those file paths.

Because `write-file-atomic` writes to a temporary file, sometimes those events are picked up by the parent process. I'd like to have access to the temporary file path so I can know to ignore it.

This PR returns `tmpfile` to the caller, either via callback or as a return value for the `sync` method.

An alternative solution — that does not require changes to `write-file-atomic` — would be to treat the file paths as prefixes, and when deciding whether to ignore a filesystem event to look for the murmurhash postfix, but that feels like too tight of a coupling between the behavior in the file watcher and that of the workers. Hence this PR.
