### PR TITLE
Use fs.rename instead of fs.renameSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,8 +189,9 @@ function writeFileSync (filename, data, options) {
     fs.closeSync(fd)
     if (options.chown) fs.chownSync(tmpfile, options.chown.uid, options.chown.gid)
     if (options.mode) fs.chmodSync(tmpfile, options.mode)
-    fs.renameSync(tmpfile, filename)
-    removeOnExit()
+    fs.rename(tmpfile, filename, function () {
+      removeOnExit()
+    })
   } catch (err) {
     removeOnExit()
     try { fs.unlinkSync(tmpfile) } catch (e) {}

--- a/index.js
+++ b/index.js
@@ -189,7 +189,8 @@ function writeFileSync (filename, data, options) {
     fs.closeSync(fd)
     if (options.chown) fs.chownSync(tmpfile, options.chown.uid, options.chown.gid)
     if (options.mode) fs.chmodSync(tmpfile, options.mode)
-    fs.rename(tmpfile, filename, function () {
+    fs.rename(tmpfile, filename, function (err) {
+      if (err) throw err
       removeOnExit()
     })
   } catch (err) {


### PR DESCRIPTION
fs.renameSync does not have the workarounds added by graceful-fs, and this causes issue in Windows. [See the polyfill in graceful-fs for more info](https://github.com/isaacs/node-graceful-fs/blob/master/polyfills.js#L94).

This should fix #28, https://github.com/facebook/jest/issues/4444 and any outstanding EACCES and EPERM on Windows for all packages that uses write-file-atomic as dependency.