### PR TITLE
support passing encoding string in options slot of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ atomic and allows you set ownership (uid/gid of the file).
 
 * filename **String**
 * data **String** | **Buffer**
-* options **Object**
+* options **Object** | **String**
   * chown **Object**
     * uid **Number**
     * gid **Number**
@@ -31,7 +31,7 @@ If multiple writes are concurrently issued to the same file, the write operation
 If provided, the **chown** option requires both **uid** and **gid** properties or else
 you'll get an error.
 
-The **encoding** option is ignored if **data** is a buffer. It defaults to 'utf8'.
+If options is a String, it's assumed to be the **encoding** option. The **encoding** option is ignored if **data** is a buffer. It defaults to 'utf8'.
 
 If the **fsync** option is **false**, writeFile will skip the final fsync call.
 

--- a/index.js
+++ b/index.js
@@ -28,11 +28,16 @@ function cleanupOnExit (tmpfile) {
 }
 
 function writeFile (filename, data, options, callback) {
-  if (options instanceof Function) {
-    callback = options
-    options = null
+  if (options) {
+    if (options instanceof Function) {
+      callback = options
+      options = {}
+    } else if (typeof options === 'string') {
+      options = { encoding: options }
+    }
+  } else {
+    options = {}
   }
-  if (!options) options = {}
 
   var Promise = options.Promise || global.Promise
   var truename
@@ -150,7 +155,8 @@ function writeFile (filename, data, options, callback) {
 }
 
 function writeFileSync (filename, data, options) {
-  if (!options) options = {}
+  if (typeof options === 'string') options = { encoding: options }
+  else if (!options) options = {}
   try {
     filename = fs.realpathSync(filename)
   } catch (ex) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -97,11 +97,14 @@ test('cleanupOnExit', function (t) {
 })
 
 test('async tests', function (t) {
-  t.plan(12)
+  t.plan(13)
   writeFileAtomic('good', 'test', {mode: '0777'}, function (err) {
     t.notOk(err, 'No errors occur when passing in options')
   })
-  writeFileAtomic('good', 'test', function (err) {
+  writeFileAtomic('good', 'test', 'utf8', function (err) {
+    t.notOk(err, 'No errors occur when passing in options as string')
+  })
+  writeFileAtomic('good', 'test', undefined, function (err) {
     t.notOk(err, 'No errors occur when NOT passing in options')
   })
   writeFileAtomic('noopen', 'test', function (err) {
@@ -137,7 +140,7 @@ test('async tests', function (t) {
 })
 
 test('sync tests', function (t) {
-  t.plan(10)
+  t.plan(11)
   var throws = function (shouldthrow, msg, todo) {
     var err
     try { todo() } catch (e) { err = e }
@@ -151,6 +154,9 @@ test('sync tests', function (t) {
 
   noexception('No errors occur when passing in options', function () {
     writeFileAtomicSync('good', 'test', {mode: '0777'})
+  })
+  noexception('No errors occur when passing in options as string', function () {
+    writeFileAtomicSync('good', 'test', 'utf8')
   })
   noexception('No errors occur when NOT passing in options', function () {
     writeFileAtomicSync('good', 'test')

--- a/test/integration.js
+++ b/test/integration.js
@@ -84,6 +84,15 @@ test('writes simple file (async)', function (t) {
   })
 })
 
+test('writes simple file with encoding (async)', function (t) {
+  t.plan(3)
+  var file = tmpFile()
+  didWriteFileAtomic(t, {}, file, 'foo', 'utf16le', function (err) {
+    t.ifError(err, 'no error')
+    t.is(readFile(file), 'f\u0000o\u0000o\u0000', 'content ok')
+  })
+})
+
 test('writes buffers to simple file (async)', function (t) {
   t.plan(3)
   var file = tmpFile()
@@ -189,6 +198,13 @@ test('writes simple file (sync)', function (t) {
   var file = tmpFile()
   didWriteFileAtomicSync(t, {}, file, '42')
   t.is(readFile(file), '42')
+})
+
+test('writes simple file with encoding (sync)', function (t) {
+  t.plan(2)
+  var file = tmpFile()
+  didWriteFileAtomicSync(t, {}, file, 'foo', 'utf16le')
+  t.is(readFile(file), 'f\u0000o\u0000o\u0000')
 })
 
 test('writes simple buffer file (sync)', function (t) {


### PR DESCRIPTION
* support passing encoding string in options slot for each function (to match node)
* document alternate form in README
* fix missing assertion when passing undefined options to async function
  * was confusing callback w/ options argument, giving false positive