### PR TITLE
Remove unneeded removeOnExit call

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,6 @@ function writeFile (filename, data, options, callback) {
       })
     })
   }).then(function success () {
-    removeOnExit()
     callback()
   }).catch(function fail (err) {
     removeOnExit()


### PR DESCRIPTION
In case of success, there seems to be no need to remove the tempfile.

I've discovered this while looking at a flamegraph using this library. There was some time spent in Error creation from the success path. And the file will not be there because it has been successfully renamed in the previous step.