### PR TITLE
support running inside of a worker thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Atomically and asynchronously writes data to a file, replacing the file if it al
 exists.  data can be a string or a buffer.
 
 The file is initially named `filename + "." + murmurhex(__filename, process.pid, ++invocations)`.
-Note that `process.pid` is replaced by `require('worker_threads').threadId` if running inside of a worker thread.
+Note that `require('worker_threads').threadId` is used in addition to `process.pid` if running inside of a worker thread.
 If writeFile completes successfully then, if passed the **chown** option it will change
 the ownership of the file. Finally it renames the file back to the filename you specified. If
 it encounters errors at any of these steps it will attempt to unlink the temporary file and then

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Atomically and asynchronously writes data to a file, replacing the file if it al
 exists.  data can be a string or a buffer.
 
 The file is initially named `filename + "." + murmurhex(__filename, process.pid, ++invocations)`.
+Note that `process.pid` is replaced by `require('worker_threads').threadId` if running inside of a worker thread.
 If writeFile completes successfully then, if passed the **chown** option it will change
 the ownership of the file. Finally it renames the file back to the filename you specified. If
 it encounters errors at any of these steps it will attempt to unlink the temporary file and then

--- a/index.js
+++ b/index.js
@@ -16,12 +16,10 @@ var threadId = (function getId () {
   try {
     var workerThreads = require('worker_threads')
 
-    if (workerThreads.isMainThread) {
-      return 0
-    }
-
-    return workerThreads.threadId || 0
+    /// if we are in main thread, this is set to `0`
+    return workerThreads.threadId
   } catch (e) {
+    // worker_threads are not available, fallback to 0
     return 0
   }
 })()

--- a/index.js
+++ b/index.js
@@ -11,17 +11,18 @@ var path = require('path')
 var activeFiles = {}
 
 // if we run inside of a worker_thread, `process.pid` is not unique
-var id = (function getId () {
+/* istanbul ignore next */
+var threadId = (function getId () {
   try {
     var workerThreads = require('worker_threads')
 
     if (workerThreads.isMainThread) {
-      return process.pid
+      return 0
     }
 
-    return workerThreads.threadId || process.pid
+    return workerThreads.threadId || 0
   } catch (e) {
-    return process.pid
+    return 0
   }
 })()
 
@@ -29,7 +30,8 @@ var invocations = 0
 function getTmpname (filename) {
   return filename + '.' +
     MurmurHash3(__filename)
-      .hash(String(id))
+      .hash(String(process.pid))
+      .hash(String(threadId))
       .hash(String(++invocations))
       .result()
 }

--- a/index.js
+++ b/index.js
@@ -10,11 +10,26 @@ var onExit = require('signal-exit')
 var path = require('path')
 var activeFiles = {}
 
+// if we run inside of a worker_thread, `process.pid` is not unique
+var id = (function getId () {
+  try {
+    var workerThreads = require('worker_threads')
+
+    if (workerThreads.isMainThread) {
+      return process.pid
+    }
+
+    return workerThreads.threadId || process.pid
+  } catch (e) {
+    return process.pid
+  }
+})()
+
 var invocations = 0
 function getTmpname (filename) {
   return filename + '.' +
     MurmurHash3(__filename)
-      .hash(String(process.pid))
+      .hash(String(id))
       .hash(String(++invocations))
       .result()
 }


### PR DESCRIPTION
Hey! 👋

Jest uses this module to write cached files to disk from within workers. It works great with `child_process.spawn`, but it doesn't work from within `worker_threads` due to `process.pid` being shared between the main thread and all its workers.

This PR will check if it's being run from within a worker, and if so, use `worker_threads.threadId`, which should be unique.

I've put together an example over in https://github.com/facebook/jest/pull/7680 whch shows `process.pid` being identical. We're super close to a release, so for now I've just copied over the source from this project into our own module - would love for you to merge this (or otherwise fix it), though! 🙂 