### PR TITLE
Fix exceptions occurring in 2.4.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,7 +224,11 @@ function writeFileSync (filename, data, options) {
     fs.renameSync(tmpfile, filename)
     removeOnExitHandler()
   } catch (err) {
-    if (fd) fs.closeSync(fd)
+    if (fd) {
+      try {
+        fs.closeSync(fd)
+      } catch(e) {}
+    }
     removeOnExitHandler()
     cleanup()
     throw err

--- a/index.js
+++ b/index.js
@@ -227,7 +227,9 @@ function writeFileSync (filename, data, options) {
     if (fd) {
       try {
         fs.closeSync(fd)
-      } catch(e) {}
+      } catch (ex) {
+        // ignore close errors at this stage, error may have closed fd already.
+      }
     }
     removeOnExitHandler()
     cleanup()


### PR DESCRIPTION
As per comments here: https://github.com/npm/write-file-atomic/commit/3365a4df7d6117473905ec3f633d9a1bb42b6b17

jest is unusable with the latest version.