### PR TITLE
Fix TypeError: callback is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,11 +53,11 @@ function writeFile (filename, data, options, callback) {
   } else {
     options = {}
   }
-  
+
   if (typeof callback === 'undefined') {
     callback = () => {}
   }
-  
+
   var Promise = options.Promise || global.Promise
   var truename
   var fd


### PR DESCRIPTION
This fixes `TypeError: callback is not a function` that occurs if a callback was not defined.

It also allows handling those errors using Promises. The `checkQueue` function still runs, regardless of whether or not the last Promise chain was successful. But now if the last chain *resolved* an error, `checkQueue` will *reject* that error.