### PR TITLE
fix: cannot set mode to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function writeFileSync (filename, data, options) {
   const removeOnExitHandler = onExit(cleanup)
 
   try {
-    fd = fs.openSync(tmpfile, 'w', options.mode)
+    fd = fs.openSync(tmpfile, 'w', options.mode || 0o666)
     if (options.tmpfileCreated) {
       options.tmpfileCreated(tmpfile)
     }


### PR DESCRIPTION
because of nodejs validation: must be a 32-bit unsigned integer or an octal string. Received false