### PR TITLE
fix: remove is-typedarray and typedarray-to-buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,6 @@ const fs = require('fs')
 const MurmurHash3 = require('imurmurhash')
 const onExit = require('signal-exit')
 const path = require('path')
-const isTypedArray = require('is-typedarray')
-const typedArrayToBuffer = require('typedarray-to-buffer')
 const { promisify } = require('util')
 const activeFiles = {}
 
@@ -110,10 +108,7 @@ async function writeFileAsync (filename, data, options = {}) {
     if (options.tmpfileCreated) {
       await options.tmpfileCreated(tmpfile)
     }
-    if (isTypedArray(data)) {
-      data = typedArrayToBuffer(data)
-    }
-    if (Buffer.isBuffer(data)) {
+    if (Buffer.isBuffer(data) || ArrayBuffer.isView(data)) {
       await promisify(fs.write)(fd, data, 0, data.length, 0)
     } else if (data != null) {
       await promisify(fs.write)(fd, String(data), 0, String(options.encoding || 'utf8'))
@@ -215,10 +210,7 @@ function writeFileSync (filename, data, options) {
     if (options.tmpfileCreated) {
       options.tmpfileCreated(tmpfile)
     }
-    if (isTypedArray(data)) {
-      data = typedArrayToBuffer(data)
-    }
-    if (Buffer.isBuffer(data)) {
+    if (Buffer.isBuffer(data) || ArrayBuffer.isView(data)) {
       fs.writeSync(fd, data, 0, data.length, 0)
     } else if (data != null) {
       fs.writeSync(fd, String(data), 0, String(options.encoding || 'utf8'))

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
   "homepage": "https://github.com/npm/write-file-atomic",
   "dependencies": {
     "imurmurhash": "^0.1.4",
-    "is-typedarray": "^1.0.0",
-    "signal-exit": "^3.0.7",
-    "typedarray-to-buffer": "^4.0.0"
+    "signal-exit": "^3.0.7"
   },
   "devDependencies": {
     "@npmcli/template-oss": "^2.7.1",


### PR DESCRIPTION
our support matrix has support for sending typed arrays directly to
buffers
