### PR TITLE
fix: prevent hash concatenation from causing hash collisions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,9 @@ function getTmpname (filename) {
   return filename + '.' +
     MurmurHash3(__filename)
       .hash(String(process.pid))
+      .hash('\0')
       .hash(String(threadId))
+      .hash('\0')
       .hash(String(++invocations))
       .result()
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
