### PR TITLE
fix: guard optional onExit cleanup handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,8 @@ function cleanupOnExit (tmpfile) {
   }
 }
 
+const noop = () => {}
+
 function serializeActiveFile (absoluteName) {
   return new Promise(resolve => {
     // make a queue if it doesn't already exist
@@ -85,7 +87,7 @@ async function writeFileAsync (filename, data, options = {}) {
   let fd
   let tmpfile
   /* istanbul ignore next -- The closure only gets called when onExit triggers */
-  const removeOnExitHandler = onExit(cleanupOnExit(() => tmpfile))
+  const removeOnExitHandler = onExit(cleanupOnExit(() => tmpfile)) || noop
   const absoluteName = path.resolve(filename)
 
   try {
@@ -211,7 +213,7 @@ function writeFileSync (filename, data, options) {
 
   let fd
   const cleanup = cleanupOnExit(tmpfile)
-  const removeOnExitHandler = onExit(cleanup)
+  const removeOnExitHandler = onExit(cleanup) || noop
 
   let threw = true
   try {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,4 +1,6 @@
 'use strict'
+const fs = require('fs')
+const path = require('path')
 const t = require('tap')
 
 let expectClose = 0
@@ -174,6 +176,22 @@ t.test('cleanupOnExit', t => {
   t.doesNotThrow(cleanup2, 'exceptions are caught')
   unlinked = []
   t.end()
+})
+
+t.test('handles onExit without remove handler', async t => {
+  const writeFileAtomicNoExitRemove = t.mock('..', {
+    'signal-exit': {
+      onExit: () => undefined,
+    },
+  })
+  const dir = t.testdir()
+  const file = path.join(dir, 'file')
+
+  await writeFileAtomicNoExitRemove(file, 'async')
+  t.equal(fs.readFileSync(file, 'utf8'), 'async')
+
+  t.doesNotThrow(() => writeFileAtomicNoExitRemove.sync(file, 'sync'))
+  t.equal(fs.readFileSync(file, 'utf8'), 'sync')
 })
 
 t.test('async tests', t => {


### PR DESCRIPTION
Fixes #84.

`signal-exit` can return `undefined` from `onExit()` in some versions/environments. `write-file-atomic` currently assumes the return value is always a remover function, so the async and sync paths can throw while leaving the `finally` cleanup section even when the write itself succeeded.

This adds a no-op fallback for the optional remover and covers both async and sync writes with a regression test that mocks `onExit()` to return `undefined`.

Verification:

- `npx tap --no-coverage test/basic.js`
- `npm run eslint -- lib/index.js test/basic.js`
- `git diff --check`
- `npm test` passes tests, coverage, and eslint locally, then fails only in `template-oss-check` because the generated repository template wants unrelated `.github` branch/template updates. I did not include those unrelated tooling changes in this bugfix PR.
